### PR TITLE
chore: Debugging horizontal sharing

### DIFF
--- a/stacks/child-no-work/input.tm.hcl
+++ b/stacks/child-no-work/input.tm.hcl
@@ -1,0 +1,6 @@
+input "pet_name" {
+  backend       = "public"
+  from_stack_id = "942a114c-93c4-4e8e-9e07-1c3423d700a5"
+  mock          = "happy-panda-foo"
+  value         = outputs.pet_name.value
+}

--- a/stacks/child-no-work/output.tf
+++ b/stacks/child-no-work/output.tf
@@ -1,0 +1,3 @@
+output "child_pet_name" {
+  value = var.pet_name
+}

--- a/stacks/child-no-work/stack.tm.hcl
+++ b/stacks/child-no-work/stack.tm.hcl
@@ -1,11 +1,11 @@
 stack {
-  name        = "child"
+  name        = "child-no-work"
   description = "I output the pet name from the parent"
-  id          = "ee0940f9-717b-439f-895d-398c55a61972"
+  id          = "18ae3989-05d8-4cc2-9abb-8ce27be96cca"
 
   tags = [
     "pet",
     "child",
-    "works",
+    "broken",
   ]
 }

--- a/stacks/parent/stack.tm.hcl
+++ b/stacks/parent/stack.tm.hcl
@@ -6,6 +6,8 @@ stack {
   tags = [
     "pet",
     "parent",
+    "works",
+    "broken",
   ]
 
   before = [


### PR DESCRIPTION
I would like to know why horizontal output sharing doesn't work. This arrangement works:
```bash
└── stacks
    └── parent
        └── child
```

but this (with the same code) arrangement:
```
└── stacks
    ├── child-no-work
    └── parent
```

Fails with an error:
```
Code generation report

Failures:

- /stacks/child-no-work
        error: backend public not found

Hint: '+', '~' and '-' mean the file was created, changed and deleted, respectively.
```

Is this intended functionality or am I doing something wrong? 


